### PR TITLE
redis-fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
      - ./app:/var/www/html
      - ./docker/php/log.conf:/usr/local/etc/php-fpm.z/zz-log.conf
      - ./docker/php/php.conf:/usr/local/etc/php/conf.d/zz-conf.ini
+    command:
+     - /usr/local/etc/redis/redis.conf
     ports:
      - "9001:9001"
     networks:

--- a/docker/redis/redis.conf
+++ b/docker/redis/redis.conf
@@ -66,7 +66,8 @@
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-bind 127.0.0.1
+#bind 127.0.0.1
+bind 0.0.0.0
 
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.


### PR DESCRIPTION
Fix for Redis config file not actually being used when initiating Redis. Also a subsequent fix for actually being able to connect to Redis in the container once the config file is being properly used.